### PR TITLE
Refactor/build proccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install --save 4all-ui
 ```jsx
 import React, { Component } from 'react'
 
-import { Button } from '4all-ui'
+import Button from '4all-ui/components/Button';
 
 class Example extends Component {
   render () {
@@ -282,11 +282,11 @@ Select props
 ### Usage
 ```javascript
 import styled from 'styled-components';
-import { theme } from '4all-ui';
+import { styles, mixins } from '4all-ui/styles';
 
 const ContainerDiv = styled.div`
-  background-color: ${theme.styles.colors.MAIN_COLOR};
-  ${theme.mixins.flexPosition({ align: 'center', justify: 'space-between', direction: 'column' })}
+  background-color: ${styles.colors.MAIN_COLOR};
+  ${mixins.flexPosition({ align: 'center', justify: 'space-between', direction: 'column' })}
 `;
 
 ```

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "4all-ui": {
       "version": "file:..",
+      "requires": {
+        "rc-pagination": "^1.17.13"
+      },
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.0.0",
@@ -118,7 +121,7 @@
               }
             },
             "@babel/parser": {
-              "version": "7.4.0",
+              "version": "7.4.2",
               "bundled": true
             },
             "@babel/traverse": {
@@ -831,6 +834,58 @@
             "to-fast-properties": "^2.0.0"
           }
         },
+        "@dump247/storybook-state": {
+          "version": "1.5.2",
+          "bundled": true,
+          "requires": {
+            "react": "^16.6.0",
+            "react-json-view": "^1.13.3"
+          }
+        },
+        "@emotion/babel-utils": {
+          "version": "0.6.10",
+          "bundled": true,
+          "requires": {
+            "@emotion/hash": "^0.6.6",
+            "@emotion/memoize": "^0.6.6",
+            "@emotion/serialize": "^0.9.1",
+            "convert-source-map": "^1.5.1",
+            "find-root": "^1.1.0",
+            "source-map": "^0.7.2"
+          },
+          "dependencies": {
+            "@emotion/hash": {
+              "version": "0.6.6",
+              "bundled": true
+            },
+            "@emotion/memoize": {
+              "version": "0.6.6",
+              "bundled": true
+            },
+            "@emotion/serialize": {
+              "version": "0.9.1",
+              "bundled": true,
+              "requires": {
+                "@emotion/hash": "^0.6.6",
+                "@emotion/memoize": "^0.6.6",
+                "@emotion/unitless": "^0.6.7",
+                "@emotion/utils": "^0.8.2"
+              }
+            },
+            "@emotion/unitless": {
+              "version": "0.6.7",
+              "bundled": true
+            },
+            "@emotion/utils": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.7.3",
+              "bundled": true
+            }
+          }
+        },
         "@emotion/cache": {
           "version": "10.0.9",
           "bundled": true,
@@ -842,7 +897,7 @@
           }
         },
         "@emotion/core": {
-          "version": "10.0.9",
+          "version": "10.0.10",
           "bundled": true,
           "requires": {
             "@emotion/cache": "^10.0.9",
@@ -892,15 +947,15 @@
           "bundled": true
         },
         "@emotion/styled": {
-          "version": "10.0.9",
+          "version": "10.0.10",
           "bundled": true,
           "requires": {
-            "@emotion/styled-base": "^10.0.9",
+            "@emotion/styled-base": "^10.0.10",
             "babel-plugin-emotion": "^10.0.9"
           }
         },
         "@emotion/styled-base": {
-          "version": "10.0.9",
+          "version": "10.0.10",
           "bundled": true,
           "requires": {
             "@emotion/is-prop-valid": "0.7.3",
@@ -948,14 +1003,142 @@
             "warning": "^3.0.0"
           }
         },
-        "@storybook/addon-actions": {
-          "version": "5.0.3",
+        "@sambego/storybook-state": {
+          "version": "1.3.4",
           "bundled": true,
           "requires": {
-            "@storybook/addons": "5.0.3",
-            "@storybook/components": "5.0.3",
-            "@storybook/core-events": "5.0.3",
-            "@storybook/theming": "5.0.3",
+            "uuid": "^3.1.0"
+          }
+        },
+        "@storybook/addon-a11y": {
+          "version": "5.0.6",
+          "bundled": true,
+          "requires": {
+            "@storybook/addons": "5.0.6",
+            "@storybook/client-logger": "5.0.6",
+            "@storybook/components": "5.0.6",
+            "@storybook/core-events": "5.0.6",
+            "@storybook/theming": "5.0.6",
+            "axe-core": "^3.1.2",
+            "common-tags": "^1.8.0",
+            "core-js": "^2.6.5",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "prop-types": "^15.6.2",
+            "react": "^16.8.1",
+            "react-dom": "^16.8.1",
+            "util-deprecate": "^1.0.2"
+          },
+          "dependencies": {
+            "@storybook/addons": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "@storybook/channels": "5.0.6",
+                "@storybook/client-logger": "5.0.6",
+                "core-js": "^2.6.5",
+                "global": "^4.3.2",
+                "util-deprecate": "^1.0.2"
+              }
+            },
+            "@storybook/channels": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "core-js": "^2.6.5"
+              }
+            },
+            "@storybook/client-logger": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "core-js": "^2.6.5"
+              }
+            },
+            "@storybook/components": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "@storybook/addons": "5.0.6",
+                "@storybook/client-logger": "5.0.6",
+                "@storybook/core-events": "5.0.6",
+                "@storybook/router": "5.0.6",
+                "@storybook/theming": "5.0.6",
+                "core-js": "^2.6.5",
+                "global": "^4.3.2",
+                "immer": "^1.12.0",
+                "js-beautify": "^1.8.9",
+                "lodash.pick": "^4.4.0",
+                "lodash.throttle": "^4.1.1",
+                "memoizerific": "^1.11.3",
+                "polished": "^2.3.3",
+                "prop-types": "^15.6.2",
+                "react": "^16.8.1",
+                "react-dom": "^16.8.1",
+                "react-focus-lock": "^1.17.7",
+                "react-helmet-async": "^0.2.0",
+                "react-inspector": "^2.3.0",
+                "react-popper-tooltip": "^2.8.0",
+                "react-syntax-highlighter": "^8.0.1",
+                "react-textarea-autosize": "^7.0.4",
+                "reactjs-popup": "^1.3.2",
+                "recompose": "^0.30.0",
+                "render-fragment": "^0.1.1"
+              }
+            },
+            "@storybook/core-events": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "core-js": "^2.6.5"
+              }
+            },
+            "@storybook/router": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "@reach/router": "^1.2.1",
+                "@storybook/theming": "5.0.6",
+                "core-js": "^2.6.5",
+                "global": "^4.3.2",
+                "memoizerific": "^1.11.3",
+                "qs": "^6.5.2"
+              }
+            },
+            "@storybook/theming": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "@emotion/core": "^10.0.7",
+                "@emotion/styled": "^10.0.7",
+                "@storybook/client-logger": "5.0.6",
+                "common-tags": "^1.8.0",
+                "core-js": "^2.6.5",
+                "deep-object-diff": "^1.1.0",
+                "emotion-theming": "^10.0.7",
+                "global": "^4.3.2",
+                "lodash.isequal": "^4.5.0",
+                "lodash.mergewith": "^4.6.1",
+                "memoizerific": "^1.11.3",
+                "polished": "^2.3.3",
+                "prop-types": "^15.6.2",
+                "react-inspector": "^2.3.1"
+              }
+            },
+            "core-js": {
+              "version": "2.6.5",
+              "bundled": true
+            }
+          }
+        },
+        "@storybook/addon-actions": {
+          "version": "5.0.5",
+          "bundled": true,
+          "requires": {
+            "@storybook/addons": "5.0.5",
+            "@storybook/components": "5.0.5",
+            "@storybook/core-events": "5.0.5",
+            "@storybook/theming": "5.0.5",
             "core-js": "^2.6.5",
             "fast-deep-equal": "^2.0.1",
             "global": "^4.3.2",
@@ -971,33 +1154,46 @@
             "core-js": {
               "version": "2.6.5",
               "bundled": true
+            }
+          }
+        },
+        "@storybook/addon-info": {
+          "version": "5.0.5",
+          "bundled": true,
+          "requires": {
+            "@storybook/addons": "5.0.5",
+            "@storybook/client-logger": "5.0.5",
+            "@storybook/components": "5.0.5",
+            "@storybook/theming": "5.0.5",
+            "core-js": "^2.6.5",
+            "global": "^4.3.2",
+            "marksy": "^6.1.0",
+            "nested-object-assign": "^1.0.1",
+            "prop-types": "^15.6.2",
+            "react": "^16.8.1",
+            "react-addons-create-fragment": "^15.5.3",
+            "react-element-to-jsx-string": "^14.0.2",
+            "react-is": "^16.8.1",
+            "react-lifecycles-compat": "^3.0.4",
+            "util-deprecate": "^1.0.2"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "2.6.5",
+              "bundled": true
             },
-            "react": {
-              "version": "16.8.4",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.13.4"
-              }
-            },
-            "scheduler": {
-              "version": "0.13.4",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
-              }
+            "react-is": {
+              "version": "16.8.5",
+              "bundled": true
             }
           }
         },
         "@storybook/addons": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
-            "@storybook/channels": "5.0.3",
-            "@storybook/client-logger": "5.0.3",
+            "@storybook/channels": "5.0.5",
+            "@storybook/client-logger": "5.0.5",
             "core-js": "^2.6.5",
             "global": "^4.3.2",
             "util-deprecate": "^1.0.2"
@@ -1010,11 +1206,11 @@
           }
         },
         "@storybook/channel-postmessage": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
-            "@storybook/channels": "5.0.3",
-            "@storybook/client-logger": "5.0.3",
+            "@storybook/channels": "5.0.5",
+            "@storybook/client-logger": "5.0.5",
             "core-js": "^2.6.5",
             "global": "^4.3.2",
             "telejson": "^2.1.0"
@@ -1027,7 +1223,7 @@
           }
         },
         "@storybook/channels": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
             "core-js": "^2.6.5"
@@ -1040,14 +1236,15 @@
           }
         },
         "@storybook/client-api": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
-            "@storybook/addons": "5.0.3",
-            "@storybook/client-logger": "5.0.3",
-            "@storybook/core-events": "5.0.3",
-            "@storybook/router": "5.0.3",
+            "@storybook/addons": "5.0.5",
+            "@storybook/client-logger": "5.0.5",
+            "@storybook/core-events": "5.0.5",
+            "@storybook/router": "5.0.5",
             "common-tags": "^1.8.0",
+            "core-js": "^2.6.5",
             "eventemitter3": "^3.1.0",
             "global": "^4.3.2",
             "is-plain-object": "^2.0.4",
@@ -1056,10 +1253,16 @@
             "lodash.mergewith": "^4.6.1",
             "memoizerific": "^1.11.3",
             "qs": "^6.5.2"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "2.6.5",
+              "bundled": true
+            }
           }
         },
         "@storybook/client-logger": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
             "core-js": "^2.6.5"
@@ -1072,14 +1275,14 @@
           }
         },
         "@storybook/components": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
-            "@storybook/addons": "5.0.3",
-            "@storybook/client-logger": "5.0.3",
-            "@storybook/core-events": "5.0.3",
-            "@storybook/router": "5.0.3",
-            "@storybook/theming": "5.0.3",
+            "@storybook/addons": "5.0.5",
+            "@storybook/client-logger": "5.0.5",
+            "@storybook/core-events": "5.0.5",
+            "@storybook/router": "5.0.5",
+            "@storybook/theming": "5.0.5",
             "core-js": "^2.6.5",
             "global": "^4.3.2",
             "immer": "^1.12.0",
@@ -1105,39 +1308,11 @@
             "core-js": {
               "version": "2.6.5",
               "bundled": true
-            },
-            "react": {
-              "version": "16.8.4",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.13.4"
-              }
-            },
-            "react-dom": {
-              "version": "16.8.4",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.13.4"
-              }
-            },
-            "scheduler": {
-              "version": "0.13.4",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
-              }
             }
           }
         },
         "@storybook/core": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
             "@babel/plugin-proposal-class-properties": "^7.3.0",
@@ -1145,15 +1320,15 @@
             "@babel/plugin-syntax-dynamic-import": "^7.2.0",
             "@babel/plugin-transform-react-constant-elements": "^7.2.0",
             "@babel/preset-env": "^7.3.1",
-            "@storybook/addons": "5.0.3",
-            "@storybook/channel-postmessage": "5.0.3",
-            "@storybook/client-api": "5.0.3",
-            "@storybook/client-logger": "5.0.3",
-            "@storybook/core-events": "5.0.3",
-            "@storybook/node-logger": "5.0.3",
-            "@storybook/router": "5.0.3",
-            "@storybook/theming": "5.0.3",
-            "@storybook/ui": "5.0.3",
+            "@storybook/addons": "5.0.5",
+            "@storybook/channel-postmessage": "5.0.5",
+            "@storybook/client-api": "5.0.5",
+            "@storybook/client-logger": "5.0.5",
+            "@storybook/core-events": "5.0.5",
+            "@storybook/node-logger": "5.0.5",
+            "@storybook/router": "5.0.5",
+            "@storybook/theming": "5.0.5",
+            "@storybook/ui": "5.0.5",
             "airbnb-js-shims": "^1 || ^2",
             "autoprefixer": "^9.4.7",
             "babel-plugin-add-react-displayname": "^0.0.5",
@@ -1247,7 +1422,7 @@
           }
         },
         "@storybook/core-events": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
             "core-js": "^2.6.5"
@@ -1260,7 +1435,7 @@
           }
         },
         "@storybook/node-logger": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -1281,15 +1456,15 @@
           }
         },
         "@storybook/react": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
             "@babel/plugin-transform-react-constant-elements": "^7.2.0",
             "@babel/preset-flow": "^7.0.0",
             "@babel/preset-react": "^7.0.0",
-            "@storybook/core": "5.0.3",
-            "@storybook/node-logger": "5.0.3",
-            "@storybook/theming": "5.0.3",
+            "@storybook/core": "5.0.5",
+            "@storybook/node-logger": "5.0.5",
+            "@storybook/theming": "5.0.5",
             "@svgr/webpack": "^4.0.3",
             "babel-plugin-named-asset-import": "^0.3.0",
             "babel-plugin-react-docgen": "^2.0.2",
@@ -1317,11 +1492,11 @@
           }
         },
         "@storybook/router": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
             "@reach/router": "^1.2.1",
-            "@storybook/theming": "5.0.3",
+            "@storybook/theming": "5.0.5",
             "core-js": "^2.6.5",
             "global": "^4.3.2",
             "memoizerific": "^1.11.3",
@@ -1335,12 +1510,12 @@
           }
         },
         "@storybook/theming": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
             "@emotion/core": "^10.0.7",
             "@emotion/styled": "^10.0.7",
-            "@storybook/client-logger": "5.0.3",
+            "@storybook/client-logger": "5.0.5",
             "common-tags": "^1.8.0",
             "core-js": "^2.6.5",
             "deep-object-diff": "^1.1.0",
@@ -1361,15 +1536,15 @@
           }
         },
         "@storybook/ui": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
-            "@storybook/addons": "5.0.3",
-            "@storybook/client-logger": "5.0.3",
-            "@storybook/components": "5.0.3",
-            "@storybook/core-events": "5.0.3",
-            "@storybook/router": "5.0.3",
-            "@storybook/theming": "5.0.3",
+            "@storybook/addons": "5.0.5",
+            "@storybook/client-logger": "5.0.5",
+            "@storybook/components": "5.0.5",
+            "@storybook/core-events": "5.0.5",
+            "@storybook/router": "5.0.5",
+            "@storybook/theming": "5.0.5",
             "core-js": "^2.6.5",
             "fast-deep-equal": "^2.0.1",
             "fuzzy-search": "^3.0.1",
@@ -1404,34 +1579,6 @@
             "core-js": {
               "version": "2.6.5",
               "bundled": true
-            },
-            "react": {
-              "version": "16.8.4",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.13.4"
-              }
-            },
-            "react-dom": {
-              "version": "16.8.4",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.13.4"
-              }
-            },
-            "scheduler": {
-              "version": "0.13.4",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
-              }
             }
           }
         },
@@ -1570,6 +1717,13 @@
         "@types/q": {
           "version": "1.5.1",
           "bundled": true
+        },
+        "@types/resolve": {
+          "version": "0.0.8",
+          "bundled": true,
+          "requires": {
+            "@types/node": "*"
+          }
         },
         "@types/unist": {
           "version": "2.0.3",
@@ -2120,10 +2274,10 @@
           },
           "dependencies": {
             "browserslist": {
-              "version": "4.5.1",
+              "version": "4.5.2",
               "bundled": true,
               "requires": {
-                "caniuse-lite": "^1.0.30000949",
+                "caniuse-lite": "^1.0.30000951",
                 "electron-to-chromium": "^1.3.116",
                 "node-releases": "^1.1.11"
               }
@@ -2133,7 +2287,7 @@
               "bundled": true
             },
             "electron-to-chromium": {
-              "version": "1.3.116",
+              "version": "1.3.119",
               "bundled": true
             },
             "node-releases": {
@@ -2151,6 +2305,10 @@
         },
         "aws4": {
           "version": "1.8.0",
+          "bundled": true
+        },
+        "axe-core": {
+          "version": "3.2.2",
           "bundled": true
         },
         "axobject-query": {
@@ -3579,6 +3737,10 @@
             }
           }
         },
+        "babel-standalone": {
+          "version": "6.26.0",
+          "bundled": true
+        },
         "babel-template": {
           "version": "6.26.0",
           "bundled": true,
@@ -3694,6 +3856,10 @@
               }
             }
           }
+        },
+        "base16": {
+          "version": "1.0.0",
+          "bundled": true
         },
         "base64-js": {
           "version": "1.3.0",
@@ -4636,6 +4802,37 @@
             "elliptic": "^6.0.0"
           }
         },
+        "create-emotion": {
+          "version": "9.2.12",
+          "bundled": true,
+          "requires": {
+            "@emotion/hash": "^0.6.2",
+            "@emotion/memoize": "^0.6.1",
+            "@emotion/stylis": "^0.7.0",
+            "@emotion/unitless": "^0.6.2",
+            "csstype": "^2.5.2",
+            "stylis": "^3.5.0",
+            "stylis-rule-sheet": "^0.0.10"
+          },
+          "dependencies": {
+            "@emotion/hash": {
+              "version": "0.6.6",
+              "bundled": true
+            },
+            "@emotion/memoize": {
+              "version": "0.6.6",
+              "bundled": true
+            },
+            "@emotion/stylis": {
+              "version": "0.7.1",
+              "bundled": true
+            },
+            "@emotion/unitless": {
+              "version": "0.6.7",
+              "bundled": true
+            }
+          }
+        },
         "create-error-class": {
           "version": "3.0.2",
           "bundled": true,
@@ -4721,6 +4918,14 @@
         "css-color-names": {
           "version": "0.0.4",
           "bundled": true
+        },
+        "css-declaration-sorter": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "postcss": "^7.0.1",
+            "timsort": "^0.3.0"
+          }
         },
         "css-loader": {
           "version": "2.1.1",
@@ -4940,6 +5145,10 @@
             "source-map": "^0.5.3"
           }
         },
+        "css-unit-converter": {
+          "version": "1.1.1",
+          "bundled": true
+        },
         "css-url-regex": {
           "version": "1.1.0",
           "bundled": true
@@ -5064,6 +5273,319 @@
               }
             }
           }
+        },
+        "cssnano-preset-default": {
+          "version": "4.0.7",
+          "bundled": true,
+          "requires": {
+            "css-declaration-sorter": "^4.0.1",
+            "cssnano-util-raw-cache": "^4.0.1",
+            "postcss": "^7.0.0",
+            "postcss-calc": "^7.0.1",
+            "postcss-colormin": "^4.0.3",
+            "postcss-convert-values": "^4.0.1",
+            "postcss-discard-comments": "^4.0.2",
+            "postcss-discard-duplicates": "^4.0.2",
+            "postcss-discard-empty": "^4.0.1",
+            "postcss-discard-overridden": "^4.0.1",
+            "postcss-merge-longhand": "^4.0.11",
+            "postcss-merge-rules": "^4.0.3",
+            "postcss-minify-font-values": "^4.0.2",
+            "postcss-minify-gradients": "^4.0.2",
+            "postcss-minify-params": "^4.0.2",
+            "postcss-minify-selectors": "^4.0.2",
+            "postcss-normalize-charset": "^4.0.1",
+            "postcss-normalize-display-values": "^4.0.2",
+            "postcss-normalize-positions": "^4.0.2",
+            "postcss-normalize-repeat-style": "^4.0.2",
+            "postcss-normalize-string": "^4.0.2",
+            "postcss-normalize-timing-functions": "^4.0.2",
+            "postcss-normalize-unicode": "^4.0.1",
+            "postcss-normalize-url": "^4.0.1",
+            "postcss-normalize-whitespace": "^4.0.2",
+            "postcss-ordered-values": "^4.1.2",
+            "postcss-reduce-initial": "^4.0.3",
+            "postcss-reduce-transforms": "^4.0.2",
+            "postcss-svgo": "^4.0.2",
+            "postcss-unique-selectors": "^4.0.1"
+          },
+          "dependencies": {
+            "caniuse-api": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "browserslist": "^4.0.0",
+                "caniuse-lite": "^1.0.0",
+                "lodash.memoize": "^4.1.2",
+                "lodash.uniq": "^4.5.0"
+              }
+            },
+            "color": {
+              "version": "3.1.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            },
+            "color-string": {
+              "version": "1.5.3",
+              "bundled": true,
+              "requires": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+              }
+            },
+            "cssesc": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-svg": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "html-comment-regex": "^1.1.0"
+              }
+            },
+            "normalize-url": {
+              "version": "3.3.0",
+              "bundled": true
+            },
+            "postcss-calc": {
+              "version": "7.0.1",
+              "bundled": true,
+              "requires": {
+                "css-unit-converter": "^1.1.1",
+                "postcss": "^7.0.5",
+                "postcss-selector-parser": "^5.0.0-rc.4",
+                "postcss-value-parser": "^3.3.1"
+              }
+            },
+            "postcss-colormin": {
+              "version": "4.0.3",
+              "bundled": true,
+              "requires": {
+                "browserslist": "^4.0.0",
+                "color": "^3.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+              }
+            },
+            "postcss-convert-values": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+              }
+            },
+            "postcss-discard-comments": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "postcss": "^7.0.0"
+              }
+            },
+            "postcss-discard-duplicates": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "postcss": "^7.0.0"
+              }
+            },
+            "postcss-discard-empty": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "postcss": "^7.0.0"
+              }
+            },
+            "postcss-discard-overridden": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "postcss": "^7.0.0"
+              }
+            },
+            "postcss-merge-longhand": {
+              "version": "4.0.11",
+              "bundled": true,
+              "requires": {
+                "css-color-names": "0.0.4",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0",
+                "stylehacks": "^4.0.0"
+              }
+            },
+            "postcss-merge-rules": {
+              "version": "4.0.3",
+              "bundled": true,
+              "requires": {
+                "browserslist": "^4.0.0",
+                "caniuse-api": "^3.0.0",
+                "cssnano-util-same-parent": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-selector-parser": "^3.0.0",
+                "vendors": "^1.0.0"
+              },
+              "dependencies": {
+                "postcss-selector-parser": {
+                  "version": "3.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "dot-prop": "^4.1.1",
+                    "indexes-of": "^1.0.1",
+                    "uniq": "^1.0.1"
+                  }
+                }
+              }
+            },
+            "postcss-minify-font-values": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+              }
+            },
+            "postcss-minify-gradients": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "cssnano-util-get-arguments": "^4.0.0",
+                "is-color-stop": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+              }
+            },
+            "postcss-minify-params": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "alphanum-sort": "^1.0.0",
+                "browserslist": "^4.0.0",
+                "cssnano-util-get-arguments": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0",
+                "uniqs": "^2.0.0"
+              }
+            },
+            "postcss-minify-selectors": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "alphanum-sort": "^1.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-selector-parser": "^3.0.0"
+              },
+              "dependencies": {
+                "postcss-selector-parser": {
+                  "version": "3.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "dot-prop": "^4.1.1",
+                    "indexes-of": "^1.0.1",
+                    "uniq": "^1.0.1"
+                  }
+                }
+              }
+            },
+            "postcss-normalize-charset": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "postcss": "^7.0.0"
+              }
+            },
+            "postcss-normalize-url": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "is-absolute-url": "^2.0.0",
+                "normalize-url": "^3.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+              }
+            },
+            "postcss-ordered-values": {
+              "version": "4.1.2",
+              "bundled": true,
+              "requires": {
+                "cssnano-util-get-arguments": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+              }
+            },
+            "postcss-reduce-initial": {
+              "version": "4.0.3",
+              "bundled": true,
+              "requires": {
+                "browserslist": "^4.0.0",
+                "caniuse-api": "^3.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0"
+              }
+            },
+            "postcss-reduce-transforms": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "cssnano-util-get-match": "^4.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+              }
+            },
+            "postcss-selector-parser": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "cssesc": "^2.0.0",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
+              }
+            },
+            "postcss-svgo": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "is-svg": "^3.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0",
+                "svgo": "^1.0.0"
+              }
+            },
+            "postcss-unique-selectors": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "alphanum-sort": "^1.0.0",
+                "postcss": "^7.0.0",
+                "uniqs": "^2.0.0"
+              }
+            }
+          }
+        },
+        "cssnano-util-get-arguments": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "cssnano-util-get-match": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "cssnano-util-raw-cache": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "postcss": "^7.0.0"
+          }
+        },
+        "cssnano-util-same-parent": {
+          "version": "4.0.1",
+          "bundled": true
         },
         "csso": {
           "version": "3.5.1",
@@ -5376,6 +5898,13 @@
             "utila": "~0.4"
           }
         },
+        "dom-helpers": {
+          "version": "3.4.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
         "dom-serializer": {
           "version": "0.1.0",
           "bundled": true,
@@ -5529,8 +6058,48 @@
           "version": "2.1.0",
           "bundled": true
         },
+        "emotion": {
+          "version": "9.2.12",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-emotion": "^9.2.11",
+            "create-emotion": "^9.2.12"
+          },
+          "dependencies": {
+            "@emotion/hash": {
+              "version": "0.6.6",
+              "bundled": true
+            },
+            "@emotion/memoize": {
+              "version": "0.6.6",
+              "bundled": true
+            },
+            "@emotion/stylis": {
+              "version": "0.7.1",
+              "bundled": true
+            },
+            "babel-plugin-emotion": {
+              "version": "9.2.11",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@emotion/babel-utils": "^0.6.4",
+                "@emotion/hash": "^0.6.2",
+                "@emotion/memoize": "^0.6.1",
+                "@emotion/stylis": "^0.7.0",
+                "babel-plugin-macros": "^2.0.0",
+                "babel-plugin-syntax-jsx": "^6.18.0",
+                "convert-source-map": "^1.5.0",
+                "find-root": "^1.1.0",
+                "mkdirp": "^0.5.1",
+                "source-map": "^0.5.7",
+                "touch": "^2.0.1"
+              }
+            }
+          }
+        },
         "emotion-theming": {
-          "version": "10.0.9",
+          "version": "10.0.10",
           "bundled": true,
           "requires": {
             "@emotion/weak-memoize": "0.2.2",
@@ -6450,6 +7019,13 @@
             "bser": "^2.0.0"
           }
         },
+        "fbemitter": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.4"
+          }
+        },
         "fbjs": {
           "version": "0.8.17",
           "bundled": true,
@@ -6648,6 +7224,14 @@
           "requires": {
             "inherits": "^2.0.3",
             "readable-stream": "^2.3.6"
+          }
+        },
+        "flux": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "fbemitter": "^2.0.0",
+            "fbjs": "^0.8.0"
           }
         },
         "focus-lock": {
@@ -6850,6 +7434,10 @@
         },
         "get-caller-file": {
           "version": "1.0.3",
+          "bundled": true
+        },
+        "get-own-enumerable-property-symbols": {
+          "version": "2.0.1",
           "bundled": true
         },
         "get-stdin": {
@@ -7269,6 +7857,10 @@
           "version": "1.2.0",
           "bundled": true
         },
+        "hex-color-regex": {
+          "version": "1.1.0",
+          "bundled": true
+        },
         "highlight.js": {
           "version": "9.12.0",
           "bundled": true
@@ -7329,6 +7921,14 @@
             "readable-stream": "^2.0.1",
             "wbuf": "^1.1.0"
           }
+        },
+        "hsl-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "hsla-regex": {
+          "version": "1.0.0",
+          "bundled": true
         },
         "html-comment-regex": {
           "version": "1.1.2",
@@ -7858,6 +8458,18 @@
             "ci-info": "^1.5.0"
           }
         },
+        "is-color-stop": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "css-color-names": "^0.0.4",
+            "hex-color-regex": "^1.1.0",
+            "hsl-regex": "^1.0.0",
+            "hsla-regex": "^1.0.0",
+            "rgb-regex": "^1.0.1",
+            "rgba-regex": "^1.0.0"
+          }
+        },
         "is-data-descriptor": {
           "version": "0.1.4",
           "bundled": true,
@@ -8037,6 +8649,10 @@
           "requires": {
             "has": "^1.0.1"
           }
+        },
+        "is-regexp": {
+          "version": "1.0.0",
+          "bundled": true
         },
         "is-resolvable": {
           "version": "1.1.0",
@@ -9440,7 +10056,7 @@
           "bundled": true
         },
         "js-yaml": {
-          "version": "3.12.1",
+          "version": "3.13.0",
           "bundled": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -9737,12 +10353,20 @@
           "version": "4.5.2",
           "bundled": true
         },
+        "lodash.curry": {
+          "version": "4.1.1",
+          "bundled": true
+        },
         "lodash.debounce": {
           "version": "4.0.8",
           "bundled": true
         },
         "lodash.defaults": {
           "version": "4.2.0",
+          "bundled": true
+        },
+        "lodash.flow": {
+          "version": "3.5.0",
           "bundled": true
         },
         "lodash.get": {
@@ -9908,6 +10532,19 @@
           "requires": {
             "prop-types": "^15.6.2",
             "unquote": "^1.1.0"
+          }
+        },
+        "marked": {
+          "version": "0.3.19",
+          "bundled": true
+        },
+        "marksy": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "babel-standalone": "^6.26.0",
+            "he": "^1.1.1",
+            "marked": "^0.3.12"
           }
         },
         "math-expression-evaluator": {
@@ -10226,6 +10863,10 @@
             }
           }
         },
+        "mkpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
         "move-concurrently": {
           "version": "1.0.1",
           "bundled": true,
@@ -10285,6 +10926,10 @@
         },
         "neo-async": {
           "version": "2.6.0",
+          "bundled": true
+        },
+        "nested-object-assign": {
+          "version": "1.0.3",
           "bundled": true
         },
         "next-tick": {
@@ -12313,6 +12958,62 @@
             }
           }
         },
+        "postcss-normalize-display-values": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "cssnano-util-get-match": "^4.0.0",
+            "postcss": "^7.0.0",
+            "postcss-value-parser": "^3.0.0"
+          }
+        },
+        "postcss-normalize-positions": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "cssnano-util-get-arguments": "^4.0.0",
+            "has": "^1.0.0",
+            "postcss": "^7.0.0",
+            "postcss-value-parser": "^3.0.0"
+          }
+        },
+        "postcss-normalize-repeat-style": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "cssnano-util-get-arguments": "^4.0.0",
+            "cssnano-util-get-match": "^4.0.0",
+            "postcss": "^7.0.0",
+            "postcss-value-parser": "^3.0.0"
+          }
+        },
+        "postcss-normalize-string": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.0",
+            "postcss": "^7.0.0",
+            "postcss-value-parser": "^3.0.0"
+          }
+        },
+        "postcss-normalize-timing-functions": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "cssnano-util-get-match": "^4.0.0",
+            "postcss": "^7.0.0",
+            "postcss-value-parser": "^3.0.0"
+          }
+        },
+        "postcss-normalize-unicode": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "browserslist": "^4.0.0",
+            "postcss": "^7.0.0",
+            "postcss-value-parser": "^3.0.0"
+          }
+        },
         "postcss-normalize-url": {
           "version": "3.0.8",
           "bundled": true,
@@ -12376,6 +13077,14 @@
                 "has-flag": "^1.0.0"
               }
             }
+          }
+        },
+        "postcss-normalize-whitespace": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "postcss": "^7.0.0",
+            "postcss-value-parser": "^3.0.0"
           }
         },
         "postcss-ordered-values": {
@@ -12927,7 +13636,7 @@
           "bundled": true
         },
         "prismjs": {
-          "version": "1.15.0",
+          "version": "1.16.0",
           "bundled": true,
           "requires": {
             "clipboard": "^2.0.0"
@@ -13059,12 +13768,16 @@
           "version": "2.1.1",
           "bundled": true
         },
+        "pure-color": {
+          "version": "1.3.0",
+          "bundled": true
+        },
         "q": {
           "version": "1.5.1",
           "bundled": true
         },
         "qs": {
-          "version": "6.6.0",
+          "version": "6.7.0",
           "bundled": true
         },
         "query-string": {
@@ -13169,14 +13882,42 @@
             "strip-json-comments": "~2.0.1"
           }
         },
+        "rc-pagination": {
+          "version": "1.17.13",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.x",
+            "prop-types": "^15.5.7",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
         "react": {
-          "version": "16.7.0",
+          "version": "16.8.5",
           "bundled": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
-            "scheduler": "^0.12.0"
+            "scheduler": "^0.13.5"
+          }
+        },
+        "react-addons-create-fragment": {
+          "version": "15.6.2",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.4",
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "react-base16-styling": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "base16": "^1.0.0",
+            "lodash.curry": "^4.0.1",
+            "lodash.flow": "^3.3.0",
+            "pure-color": "^1.2.0"
           }
         },
         "react-clientside-effect": {
@@ -13350,13 +14091,13 @@
           }
         },
         "react-dom": {
-          "version": "16.7.0",
+          "version": "16.8.5",
           "bundled": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
-            "scheduler": "^0.12.0"
+            "scheduler": "^0.13.5"
           }
         },
         "react-draggable": {
@@ -13365,6 +14106,14 @@
           "requires": {
             "classnames": "^2.2.5",
             "prop-types": "^15.6.0"
+          }
+        },
+        "react-element-to-jsx-string": {
+          "version": "14.0.2",
+          "bundled": true,
+          "requires": {
+            "is-plain-object": "2.0.4",
+            "stringify-object": "3.2.2"
           }
         },
         "react-error-overlay": {
@@ -13402,6 +14151,13 @@
             "prop-types": "^15.6.1"
           }
         },
+        "react-input-autosize": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "prop-types": "^15.5.8"
+          }
+        },
         "react-inspector": {
           "version": "2.3.1",
           "bundled": true,
@@ -13414,6 +14170,25 @@
         "react-is": {
           "version": "16.7.0",
           "bundled": true
+        },
+        "react-json-view": {
+          "version": "1.19.1",
+          "bundled": true,
+          "requires": {
+            "flux": "^3.1.3",
+            "react-base16-styling": "^0.6.0",
+            "react-lifecycles-compat": "^3.0.4",
+            "react-textarea-autosize": "^6.1.0"
+          },
+          "dependencies": {
+            "react-textarea-autosize": {
+              "version": "6.1.0",
+              "bundled": true,
+              "requires": {
+                "prop-types": "^15.6.0"
+              }
+            }
+          }
         },
         "react-lifecycles-compat": {
           "version": "3.0.4",
@@ -13474,6 +14249,64 @@
             "lodash-es": "^4.17.11",
             "prop-types": "^15.6.2",
             "resize-observer-polyfill": "^1.5.1"
+          }
+        },
+        "react-router": {
+          "version": "4.3.1",
+          "bundled": true,
+          "requires": {
+            "history": "^4.7.2",
+            "hoist-non-react-statics": "^2.5.0",
+            "invariant": "^2.2.4",
+            "loose-envify": "^1.3.1",
+            "path-to-regexp": "^1.7.0",
+            "prop-types": "^15.6.1",
+            "warning": "^4.0.1"
+          },
+          "dependencies": {
+            "hoist-non-react-statics": {
+              "version": "2.5.5",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "path-to-regexp": {
+              "version": "1.7.0",
+              "bundled": true,
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            },
+            "warning": {
+              "version": "4.0.3",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.0.0"
+              }
+            }
+          }
+        },
+        "react-router-dom": {
+          "version": "4.3.1",
+          "bundled": true,
+          "requires": {
+            "history": "^4.7.2",
+            "invariant": "^2.2.4",
+            "loose-envify": "^1.3.1",
+            "prop-types": "^15.6.1",
+            "react-router": "^4.3.1",
+            "warning": "^4.0.1"
+          },
+          "dependencies": {
+            "warning": {
+              "version": "4.0.3",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.0.0"
+              }
+            }
           }
         },
         "react-scripts": {
@@ -14556,6 +15389,25 @@
             }
           }
         },
+        "react-select": {
+          "version": "2.4.2",
+          "bundled": true,
+          "requires": {
+            "classnames": "^2.2.5",
+            "emotion": "^9.1.2",
+            "memoize-one": "^5.0.0",
+            "prop-types": "^15.6.0",
+            "raf": "^3.4.0",
+            "react-input-autosize": "^2.2.1",
+            "react-transition-group": "^2.2.1"
+          },
+          "dependencies": {
+            "memoize-one": {
+              "version": "5.0.4",
+              "bundled": true
+            }
+          }
+        },
         "react-syntax-highlighter": {
           "version": "8.1.0",
           "bundled": true,
@@ -14573,6 +15425,16 @@
           "requires": {
             "@babel/runtime": "^7.1.2",
             "prop-types": "^15.6.0"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
           }
         },
         "reactjs-popup": {
@@ -14761,6 +15623,15 @@
             "hastscript": "^5.0.0",
             "parse-entities": "^1.1.2",
             "prismjs": "~1.15.0"
+          },
+          "dependencies": {
+            "prismjs": {
+              "version": "1.15.0",
+              "bundled": true,
+              "requires": {
+                "clipboard": "^2.0.0"
+              }
+            }
           }
         },
         "regenerate": {
@@ -15089,6 +15960,14 @@
           "version": "0.1.15",
           "bundled": true
         },
+        "rgb-regex": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "rgba-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
         "right-align": {
           "version": "0.1.3",
           "bundled": true,
@@ -15112,11 +15991,22 @@
           }
         },
         "rollup": {
-          "version": "0.64.1",
+          "version": "1.11.3",
           "bundled": true,
           "requires": {
             "@types/estree": "0.0.39",
-            "@types/node": "*"
+            "@types/node": "^11.13.9",
+            "acorn": "^6.1.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "11.13.10",
+              "bundled": true
+            },
+            "acorn": {
+              "version": "6.1.1",
+              "bundled": true
+            }
           }
         },
         "rollup-plugin-babel": {
@@ -15150,17 +16040,25 @@
             "rollup-pluginutils": "^2.3.3"
           }
         },
-        "rollup-plugin-node-resolve": {
-          "version": "3.4.0",
+        "rollup-plugin-multi-input": {
+          "version": "0.2.2",
           "bundled": true,
           "requires": {
-            "builtin-modules": "^2.0.0",
+            "fast-glob": "^2.2.4"
+          }
+        },
+        "rollup-plugin-node-resolve": {
+          "version": "4.2.3",
+          "bundled": true,
+          "requires": {
+            "@types/resolve": "0.0.8",
+            "builtin-modules": "^3.1.0",
             "is-module": "^1.0.0",
-            "resolve": "^1.1.6"
+            "resolve": "^1.10.0"
           },
           "dependencies": {
             "builtin-modules": {
-              "version": "2.0.0",
+              "version": "3.1.0",
               "bundled": true
             }
           }
@@ -15170,19 +16068,18 @@
           "bundled": true
         },
         "rollup-plugin-postcss": {
-          "version": "1.6.3",
+          "version": "2.0.3",
           "bundled": true,
           "requires": {
-            "chalk": "^2.0.0",
+            "chalk": "^2.4.2",
             "concat-with-sourcemaps": "^1.0.5",
-            "cssnano": "^3.10.0",
-            "fs-extra": "^5.0.0",
+            "cssnano": "^4.1.8",
             "import-cwd": "^2.1.0",
             "p-queue": "^2.4.2",
             "pify": "^3.0.0",
-            "postcss": "^6.0.21",
-            "postcss-load-config": "^1.2.0",
-            "postcss-modules": "^1.1.0",
+            "postcss": "^7.0.14",
+            "postcss-load-config": "^2.0.0",
+            "postcss-modules": "^1.4.1",
             "promise.series": "^0.2.0",
             "reserved-words": "^0.1.2",
             "resolve": "^1.5.0",
@@ -15190,163 +16087,44 @@
             "style-inject": "^0.3.0"
           },
           "dependencies": {
-            "cosmiconfig": {
-              "version": "2.2.2",
+            "cssnano": {
+              "version": "4.1.10",
               "bundled": true,
               "requires": {
-                "is-directory": "^0.3.1",
-                "js-yaml": "^3.4.3",
-                "minimist": "^1.2.0",
-                "object-assign": "^4.1.0",
-                "os-homedir": "^1.0.1",
-                "parse-json": "^2.2.0",
-                "require-from-string": "^1.1.0"
+                "cosmiconfig": "^5.0.0",
+                "cssnano-preset-default": "^4.0.7",
+                "is-resolvable": "^1.0.0",
+                "postcss": "^7.0.0"
               }
-            },
-            "fs-extra": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-              }
-            },
-            "jsonfile": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.6"
-              }
-            },
-            "parse-json": {
-              "version": "2.2.0",
-              "bundled": true,
-              "requires": {
-                "error-ex": "^1.2.0"
-              }
-            },
-            "postcss": {
-              "version": "6.0.23",
-              "bundled": true,
-              "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-              }
-            },
-            "postcss-load-config": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "cosmiconfig": "^2.1.0",
-                "object-assign": "^4.1.0",
-                "postcss-load-options": "^1.2.0",
-                "postcss-load-plugins": "^2.3.0"
-              }
-            },
-            "require-from-string": {
-              "version": "1.2.1",
-              "bundled": true
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
             }
           }
         },
         "rollup-plugin-url": {
-          "version": "1.4.0",
+          "version": "2.2.1",
           "bundled": true,
           "requires": {
             "mime": "^2.3.1",
-            "rollup-pluginutils": "^2.0.1"
+            "mkpath": "^1.0.0",
+            "rollup-pluginutils": "^2.3.3"
           },
           "dependencies": {
             "mime": {
-              "version": "2.4.0",
+              "version": "2.4.2",
               "bundled": true
             }
           }
         },
         "rollup-pluginutils": {
-          "version": "2.3.3",
+          "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "estree-walker": "^0.5.2",
-            "micromatch": "^2.3.11"
+            "estree-walker": "^0.6.0",
+            "micromatch": "^3.1.10"
           },
           "dependencies": {
-            "arr-diff": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "arr-flatten": "^1.0.1"
-              }
-            },
-            "array-unique": {
-              "version": "0.2.1",
+            "estree-walker": {
+              "version": "0.6.0",
               "bundled": true
-            },
-            "braces": {
-              "version": "1.8.5",
-              "bundled": true,
-              "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
-              }
-            },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "is-posix-bracket": "^0.1.0"
-              }
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            },
-            "kind-of": {
-              "version": "3.2.2",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            },
-            "micromatch": {
-              "version": "2.3.11",
-              "bundled": true,
-              "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
-              }
             }
           }
         },
@@ -15521,7 +16299,7 @@
           }
         },
         "scheduler": {
-          "version": "0.12.0",
+          "version": "0.13.5",
           "bundled": true,
           "requires": {
             "loose-envify": "^1.1.0",
@@ -15764,6 +16542,19 @@
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true
+        },
+        "simple-swizzle": {
+          "version": "0.2.2",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "^0.3.1"
+          },
+          "dependencies": {
+            "is-arrayish": {
+              "version": "0.3.2",
+              "bundled": true
+            }
+          }
         },
         "slash": {
           "version": "1.0.0",
@@ -16117,6 +16908,28 @@
           "version": "1.1.1",
           "bundled": true
         },
+        "storybook-react-router": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "prop-types": "^15.7.2"
+          },
+          "dependencies": {
+            "prop-types": {
+              "version": "15.7.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+              }
+            },
+            "react-is": {
+              "version": "16.8.5",
+              "bundled": true
+            }
+          }
+        },
         "stream-browserify": {
           "version": "2.0.2",
           "bundled": true,
@@ -16220,6 +17033,15 @@
             "safe-buffer": "~5.1.0"
           }
         },
+        "stringify-object": {
+          "version": "3.2.2",
+          "bundled": true,
+          "requires": {
+            "get-own-enumerable-property-symbols": "^2.0.1",
+            "is-obj": "^1.0.1",
+            "is-regexp": "^1.0.0"
+          }
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "bundled": true,
@@ -16284,6 +17106,26 @@
             "stylis": "^3.5.0",
             "stylis-rule-sheet": "^0.0.10",
             "supports-color": "^5.5.0"
+          }
+        },
+        "stylehacks": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "browserslist": "^4.0.0",
+            "postcss": "^7.0.0",
+            "postcss-selector-parser": "^3.0.0"
+          },
+          "dependencies": {
+            "postcss-selector-parser": {
+              "version": "3.1.1",
+              "bundled": true,
+              "requires": {
+                "dot-prop": "^4.1.1",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
+              }
+            }
           }
         },
         "stylis": {
@@ -16740,6 +17582,10 @@
             "setimmediate": "^1.0.4"
           }
         },
+        "timsort": {
+          "version": "0.3.0",
+          "bundled": true
+        },
         "tiny-emitter": {
           "version": "2.1.0",
           "bundled": true,
@@ -16809,6 +17655,22 @@
         "toposort": {
           "version": "1.0.7",
           "bundled": true
+        },
+        "touch": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "nopt": "~1.0.10"
+          },
+          "dependencies": {
+            "nopt": {
+              "version": "1.0.10",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1"
+              }
+            }
+          }
         },
         "tough-cookie": {
           "version": "2.5.0",
@@ -17943,12 +18805,12 @@
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
     },
     "accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "requires": {
-        "mime-types": "~2.1.18",
-        "negotiator": "0.6.1"
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
       }
     },
     "acorn": {
@@ -18206,10 +19068,11 @@
       }
     },
     "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "requires": {
+        "object-assign": "^4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
@@ -18252,9 +19115,9 @@
       }
     },
     "async-each": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
-      "integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -19189,14 +20052,14 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-      "integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -19529,14 +20392,14 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000951",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000951.tgz",
-      "integrity": "sha512-Nb8bgexT3HDxPMFOLcT5kol/dHsXpPiiFLU079+msbSBTsq9zZaCpzqDb122+9B9woZnTG5Z8lt+3adIaxKj2A=="
+      "version": "1.0.30000967",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000967.tgz",
+      "integrity": "sha512-70gk6cLSD5rItxnZ7WUxyCpM9LAjEb1tVzlENQfXQXZS/IiGnfAC6u32G5cZFlDBKjNPBIta/QSx5CZLZepxRA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30000951",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000951.tgz",
-      "integrity": "sha512-eRhP+nQ6YUkIcNQ6hnvdhMkdc7n3zadog0KXNRxAZTT2kHjUb1yGn71OrPhSn8MOvlX97g5CR97kGVj8fMsXWg=="
+      "version": "1.0.30000967",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000967.tgz",
+      "integrity": "sha512-rUBIbap+VJfxTzrM4akJ00lkvVb5/n5v3EGXfWzSH5zT8aJmGzjA8HWhJ4U6kCpzxozUSnB+yvAYDRPY6mRpgQ=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -19592,9 +20455,9 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
     "chokidar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
-      "integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
+      "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
       "requires": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
@@ -19607,7 +20470,7 @@
         "normalize-path": "^3.0.0",
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
-        "upath": "^1.1.0"
+        "upath": "^1.1.1"
       },
       "dependencies": {
         "anymatch": {
@@ -19854,9 +20717,9 @@
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-glob": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "requires": {
             "is-extglob": "^2.1.1"
           }
@@ -20112,9 +20975,9 @@
       }
     },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -20122,16 +20985,16 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "compressible": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.16.tgz",
-      "integrity": "sha512-JQfEOdnI7dASwCuSPWIeVYwc/zMsu/+tRhoUvEfXz2gxOA2DNjmG5vhtFdBlhWPPGo+RdT9S3tgc/uH5qgDiiA==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+      "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
       "requires": {
-        "mime-db": ">= 1.38.0 < 2"
+        "mime-db": ">= 1.40.0 < 2"
       }
     },
     "compression": {
@@ -20582,9 +21445,9 @@
       }
     },
     "damerau-levenshtein": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
-      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+      "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -20900,9 +21763,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.116",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.116.tgz",
-      "integrity": "sha512-NKwKAXzur5vFCZYBHpdWjTMO8QptNLNP80nItkSIgUOapPAo9Uia+RvkCaZJtO7fhQaVElSvBPWEc2ku6cKsPA=="
+      "version": "1.3.133",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.133.tgz",
+      "integrity": "sha512-lyoC8aoqbbDqsprb6aPdt9n3DpOZZzdz/T4IZKsR0/dkZIxnJVUjjcpOSwA66jPRIOyDAamCTAUqweU05kKNSg=="
     },
     "elliptic": {
       "version": "6.4.1",
@@ -20989,9 +21852,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.49",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
-      "integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
@@ -21171,9 +22034,9 @@
           "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "js-yaml": {
-          "version": "3.12.2",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-          "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -21221,9 +22084,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
       "requires": {
         "debug": "^2.6.8",
         "pkg-dir": "^2.0.0"
@@ -21350,9 +22213,9 @@
           "dev": true
         },
         "jsx-ast-utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-          "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
+          "integrity": "sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==",
           "dev": true,
           "requires": {
             "array-includes": "^3.0.3"
@@ -21372,9 +22235,9 @@
       },
       "dependencies": {
         "jsx-ast-utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-          "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
+          "integrity": "sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==",
           "requires": {
             "array-includes": "^3.0.3"
           }
@@ -21445,9 +22308,9 @@
       }
     },
     "eventemitter3": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "events": {
       "version": "3.0.0",
@@ -21850,13 +22713,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -21866,8 +22729,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -21885,13 +22747,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -21904,18 +22764,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -21923,11 +22780,11 @@
           "optional": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "4.1.1",
           "bundled": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
@@ -22018,8 +22875,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -22029,7 +22885,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -22042,20 +22897,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -22072,28 +22924,27 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true,
           "optional": true
         },
         "needle": {
-          "version": "2.2.4",
+          "version": "2.3.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.3",
+          "version": "0.12.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -22119,12 +22970,12 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.2.0",
+          "version": "1.4.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -22145,8 +22996,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -22156,7 +23006,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -22232,8 +23081,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -22246,7 +23094,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.6.0",
+          "version": "5.7.0",
           "bundled": true,
           "optional": true
         },
@@ -22263,7 +23111,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -22281,7 +23128,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -22320,13 +23166,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -22369,9 +23213,9 @@
       }
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -22488,9 +23332,9 @@
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
     },
     "handlebars": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -22765,9 +23609,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -22870,9 +23714,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "3.3.10",
@@ -23013,9 +23857,9 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
     "is-absolute-url": {
       "version": "2.1.0",
@@ -23900,9 +24744,9 @@
       }
     },
     "loader-fs-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
-      "integrity": "sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
+      "integrity": "sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==",
       "requires": {
         "find-cache-dir": "^0.1.1",
         "mkdirp": "0.5.1"
@@ -24239,16 +25083,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "requires": {
-        "mime-db": "~1.38.0"
+        "mime-db": "1.40.0"
       }
     },
     "mimic-fn": {
@@ -24331,9 +25175,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
-      "integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "optional": true
     },
     "nanomatch": {
@@ -24377,9 +25221,9 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "neo-async": {
       "version": "2.6.0",
@@ -24470,9 +25314,9 @@
       },
       "dependencies": {
         "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
           "requires": {
             "path-parse": "^1.0.6"
           }
@@ -24570,9 +25414,9 @@
       "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
     },
     "object-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -24813,9 +25657,9 @@
       "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
     },
     "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -26173,12 +27017,12 @@
       }
     },
     "proxy-addr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.8.0"
+        "ipaddr.js": "1.9.0"
       }
     },
     "prr": {
@@ -26244,9 +27088,9 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "querystringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "raf": {
       "version": "3.4.0",
@@ -26340,14 +27184,14 @@
       }
     },
     "react": {
-      "version": "16.8.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
-      "integrity": "sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
+      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.4"
+        "scheduler": "^0.13.6"
       }
     },
     "react-dev-utils": {
@@ -26376,14 +27220,14 @@
       }
     },
     "react-dom": {
-      "version": "16.8.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.4.tgz",
-      "integrity": "sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
+      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.4"
+        "scheduler": "^0.13.6"
       }
     },
     "react-error-overlay": {
@@ -26392,9 +27236,9 @@
       "integrity": "sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw=="
     },
     "react-is": {
-      "version": "16.8.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
-      "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA=="
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
     "react-scripts": {
       "version": "1.1.5",
@@ -27188,9 +28032,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scheduler": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
-      "integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -27218,9 +28062,9 @@
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -27587,9 +28431,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
     },
     "spdy": {
       "version": "3.4.7",
@@ -28069,12 +28913,12 @@
       }
     },
     "type-is": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "~2.1.24"
       }
     },
     "typedarray": {
@@ -28089,6 +28933,13 @@
       "requires": {
         "commander": "~2.19.0",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+        }
       }
     },
     "uglify-to-browserify": {
@@ -28345,11 +29196,11 @@
       }
     },
     "url-parse": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
-      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "requires": {
-        "querystringify": "^2.0.0",
+        "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
     },
@@ -28409,9 +29260,9 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vendors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
-      "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
+      "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw=="
     },
     "verror": {
       "version": "1.10.0",
@@ -28876,9 +29727,9 @@
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "worker-farm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-      "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "requires": {
         "errno": "~0.1.7"
       }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import { Tag } from '4all-ui'
+import Tag from '4all-ui/dist/components/Tag';
 
 export default class App extends Component {
   render () {

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 
 import Tag from '4all-ui/dist/components/Tag';
+import { styles, mixins } from '4all-ui/dist/styles';
 
 export default class App extends Component {
   render () {
@@ -10,7 +11,7 @@ export default class App extends Component {
         marginLeft:'320px',
         display: 'flex',
       }}>
-        <Tag showCloseIcon>Label</Tag>
+        <Tag bgColor={styles.colors.DANGER_COLOR} showCloseIcon>Label</Tag>
         <Tag secondary>Label</Tag>
       </div>
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -8884,14 +8884,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8906,20 +8904,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9036,8 +9031,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9049,7 +9043,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9064,7 +9057,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9072,14 +9064,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9098,7 +9088,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9179,8 +9168,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9192,7 +9180,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9314,7 +9301,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -20372,6 +20358,15 @@
         "rollup-pluginutils": "^2.3.3"
       }
     },
+    "rollup-plugin-multi-input": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-multi-input/-/rollup-plugin-multi-input-0.2.2.tgz",
+      "integrity": "sha512-vbkNtNkQQSy5L2GrVOW5RhFewwkj6bx7Z4V+eL5wHgaZk3p+AF39955sMyLhe1zA81sshMqkqhjio8z10p7EUw==",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^2.2.4"
+      }
+    },
     "rollup-plugin-node-resolve": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.4.0.tgz",
@@ -20512,9 +20507,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-          "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+          "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "cross-env CI=1 react-scripts test --env=jsdom",
     "test:watch": "react-scripts test --env=jsdom",
     "build": "rollup -c --experimentalCodeSplitting",
-    "start": "rollup -c -w",
+    "start": "rollup -c -w --experimentalCodeSplitting",
     "prepare": "npm run build",
     "storybook": "start-storybook",
     "predeploy": "build-storybook -c .storybook",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "test": "cross-env CI=1 react-scripts test --env=jsdom",
     "test:watch": "react-scripts test --env=jsdom",
-    "build": "rollup -c",
+    "build": "rollup -c --experimentalCodeSplitting",
     "start": "rollup -c -w",
     "prepare": "npm run build",
     "storybook": "start-storybook",
@@ -74,6 +74,7 @@
     "rollup": "^0.64.1",
     "rollup-plugin-babel": "^3.0.7",
     "rollup-plugin-commonjs": "^9.1.3",
+    "rollup-plugin-multi-input": "^0.2.2",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-postcss": "^1.6.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ import svgr from '@svgr/rollup';
 import pkg from './package.json'
 
 export default {
-  input: ['src/components/**/index.js'],
+  input: ['src/components/**/index.js', 'src/styles/index.js'],
   output: [
     {
       /* file: pkg.main, */

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,25 +1,29 @@
-import babel from 'rollup-plugin-babel'
-import commonjs from 'rollup-plugin-commonjs'
-import external from 'rollup-plugin-peer-deps-external'
-import postcss from 'rollup-plugin-postcss'
-import resolve from 'rollup-plugin-node-resolve'
-import url from 'rollup-plugin-url'
-import svgr from '@svgr/rollup'
+import babel from 'rollup-plugin-babel';
+import commonjs from 'rollup-plugin-commonjs';
+import external from 'rollup-plugin-peer-deps-external';
+import postcss from 'rollup-plugin-postcss';
+import resolve from 'rollup-plugin-node-resolve';
+import url from 'rollup-plugin-url';
+import multiInput from 'rollup-plugin-multi-input';
+import svgr from '@svgr/rollup';
 
 import pkg from './package.json'
 
 export default {
-  input: 'src/index.js',
+  input: ['src/components/**/index.js'],
   output: [
     {
-      file: pkg.main,
+      /* file: pkg.main, */
       format: 'cjs',
-      sourcemap: true
+      dir: 'dist',
+      sourcemap: true,
+      exports: 'named',
     },
     {
-      file: pkg.module,
+      dir: 'dist',
       format: 'es',
-      sourcemap: true
+      sourcemap: true,
+      exports: 'named',
     }
   ],
   plugins: [
@@ -34,6 +38,7 @@ export default {
       plugins: [ 'external-helpers' ]
     }),
     resolve(),
-    commonjs()
+    commonjs(),
+    multiInput(),
   ]
 }

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,0 +1,7 @@
+import styles from './variables';
+import * as mixins from './mixins';
+
+export {
+  styles,
+  mixins,
+};


### PR DESCRIPTION
refactor 4all-ui library build process to add code-splitting. Now we import our component as modules eg. `4all-ui/components/Button`, that way, we only import Button deps and not all deps needed by all our components (eg. `react-select`, `rc-pagination`)